### PR TITLE
Enable minimal CI builds

### DIFF
--- a/.github/workflows/gradle-ci-workflow.yaml
+++ b/.github/workflows/gradle-ci-workflow.yaml
@@ -27,7 +27,6 @@ jobs:
         run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.1.6352462" --sdk_root=${ANDROID_SDK_ROOT}
       - uses: eskatos/gradle-command-action@v1
         with:
-          gradle-version: 5.6.4
           arguments: assembleFullDebug
           wrapper-cache-enabled: true
           dependencies-cache-enabled: true

--- a/.github/workflows/gradle-ci-workflow.yaml
+++ b/.github/workflows/gradle-ci-workflow.yaml
@@ -1,0 +1,34 @@
+name: Gradle CI
+
+on:
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Create NDK path
+        run: sudo mkdir -p /usr/local/lib/android/sdk/ndk && sudo chmod 777 /usr/local/lib/android/sdk/ndk
+      - name: Cache NDKs
+        id: cache-ndk
+        uses: actions/cache@v2
+        with:
+          path: /usr/local/lib/android/sdk/ndk
+          key: ${{ runner.os }}-ndk-21.0.6113669-21.1.6352462
+      - name: Install NDK 21.0.6113669
+        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
+      - name: Install NDK 21.1.6352462
+        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.1.6352462" --sdk_root=${ANDROID_SDK_ROOT}
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          gradle-version: 5.6.4
+          arguments: assembleFullDebug
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true


### PR DESCRIPTION
This just builds the fullDebug configuration for now, it does not run unit tests.
But it's a start! :)

Unfortunately, we have to install two additional NDK versions, which takes almost as long as building the sources, but we'll have to live with that. I added caching for the NDKs to mitigate the overhead.