### PR TITLE
Move SingleClickButton to core

### DIFF
--- a/app/src/main/java/info/nightscout/androidaps/plugins/general/actions/ActionsFragment.kt
+++ b/app/src/main/java/info/nightscout/androidaps/plugins/general/actions/ActionsFragment.kt
@@ -25,7 +25,7 @@ import info.nightscout.androidaps.plugins.general.actions.defs.CustomAction
 import info.nightscout.androidaps.plugins.general.overview.StatusLightHandler
 import info.nightscout.androidaps.queue.Callback
 import info.nightscout.androidaps.utils.FabricPrivacy
-import info.nightscout.androidaps.utils.SingleClickButton
+import info.nightscout.androidaps.utils.ui.SingleClickButton
 import info.nightscout.androidaps.utils.alertDialogs.OKDialog
 import info.nightscout.androidaps.utils.buildHelper.BuildHelper
 import info.nightscout.androidaps.utils.extensions.plusAssign

--- a/app/src/main/res/layout/actions_fragment.xml
+++ b/app/src/main/res/layout/actions_fragment.xml
@@ -25,7 +25,7 @@
             android:padding="10dip"
             app:columnCount="2">
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_profileswitch"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -40,7 +40,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="0" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_temptarget"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -55,7 +55,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="0" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_settempbasal"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -70,7 +70,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="1" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_canceltempbasal"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -86,7 +86,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="1" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_extendedbolus"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -101,7 +101,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="1" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_extendedbolus_cancel"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -139,7 +139,7 @@
             android:padding="10dip"
             app:columnCount="2">
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_bgcheck"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -154,7 +154,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="2" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_fill"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -169,7 +169,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="2" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_cgmsensorinsert"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -183,7 +183,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="3" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_pumpbatterychange"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -197,7 +197,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="3" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_note"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -211,7 +211,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="4" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_exercise"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -225,7 +225,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="4" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_announcement"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -239,7 +239,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="5" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_question"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -268,7 +268,7 @@
             android:padding="10dip"
             app:columnCount="2">
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_historybrowser"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"
@@ -282,7 +282,7 @@
                 app:layout_gravity="fill"
                 app:layout_row="6" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_tddstats"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_smscommunicator_otp.xml
+++ b/app/src/main/res/layout/activity_smscommunicator_otp.xml
@@ -86,7 +86,7 @@
                 style="@style/warning_label"
                 android:text="@string/smscommunicator_otp_reset_warning" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/actions_smscommunicator_otp_reset"
                 style="?android:attr/buttonStyle"
                 android:layout_width="fill_parent"

--- a/app/src/main/res/layout/careportal_fragment.xml
+++ b/app/src/main/res/layout/careportal_fragment.xml
@@ -45,7 +45,7 @@
                     android:padding="10dip"
                     app:columnCount="3">
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_bgcheck"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0px"
@@ -60,7 +60,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="0" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_exercise"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -74,7 +74,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="0" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_temporarytarget"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -105,7 +105,7 @@
                     android:padding="10dip"
                     app:columnCount="3">
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_snackbolus"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -119,7 +119,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="1" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_mealbolus"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -133,7 +133,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="1" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_correctionbolus"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -147,7 +147,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="1" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_carbscorrection"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -161,7 +161,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="2" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_combobolus"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -175,7 +175,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="2" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_tempbasalstart"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -189,7 +189,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="2" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_tempbasalend"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -219,7 +219,7 @@
                     android:padding="10dip"
                     app:columnCount="3">
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_cgmsensorstart"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -234,7 +234,7 @@
                         app:layout_row="1" />
 
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_cgmsensorinsert"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -249,7 +249,7 @@
                         app:layout_row="1" />
 
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_openapsoffline"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -264,7 +264,7 @@
                         app:layout_row="1" />
 
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_announcement"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -278,7 +278,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="4" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_question"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -292,7 +292,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="4" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_note"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -321,7 +321,7 @@
                     android:padding="10dip"
                     app:columnCount="3">
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_pumpsitechange"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -335,7 +335,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="0" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_insulincartridgechange"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -349,7 +349,7 @@
                         app:layout_gravity="fill"
                         app:layout_row="0" />
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_profileswitch"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"
@@ -364,7 +364,7 @@
                         app:layout_row="0" />
 
 
-                    <info.nightscout.androidaps.utils.SingleClickButton
+                    <info.nightscout.androidaps.utils.ui.SingleClickButton
                         android:id="@+id/careportal_pumpbatterychange"
                         style="@style/ButtonSmallFontStyle"
                         android:layout_width="0dp"

--- a/app/src/main/res/layout/combopump_fragment.xml
+++ b/app/src/main/res/layout/combopump_fragment.xml
@@ -487,7 +487,7 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/combo_refresh_button"
                 style="@style/ButtonSmallFontStyle"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/overview_buttons_layout.xml
+++ b/app/src/main/res/layout/overview_buttons_layout.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <info.nightscout.androidaps.utils.SingleClickButton
+    <info.nightscout.androidaps.utils.ui.SingleClickButton
         android:id="@+id/overview_accepttempbutton"
         style="?android:attr/buttonStyle"
         android:layout_width="match_parent"
@@ -25,7 +25,7 @@
         android:paddingStart="0dp"
         android:paddingEnd="5dp" >
 
-        <info.nightscout.androidaps.utils.SingleClickButton
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/overview_treatmentbutton"
             style="?android:attr/buttonStyle"
             android:layout_width="0px"
@@ -38,7 +38,7 @@
             android:textSize="10sp"
             android:visibility="gone" />
 
-        <info.nightscout.androidaps.utils.SingleClickButton
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/overview_insulinbutton"
             style="?android:attr/buttonStyle"
             android:layout_width="0px"
@@ -50,7 +50,7 @@
             android:textColor="@color/colorInsulinButton"
             android:textSize="10sp" />
 
-        <info.nightscout.androidaps.utils.SingleClickButton
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/overview_carbsbutton"
             style="?android:attr/buttonStyle"
             android:layout_width="0px"
@@ -62,7 +62,7 @@
             android:textColor="@color/colorCarbsButton"
             android:textSize="10sp" />
 
-        <info.nightscout.androidaps.utils.SingleClickButton
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/overview_wizardbutton"
             style="?android:attr/buttonStyle"
             android:layout_width="0px"
@@ -74,7 +74,7 @@
             android:textColor="@color/colorCalculatorButton"
             android:textSize="10sp" />
 
-        <info.nightscout.androidaps.utils.SingleClickButton
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/overview_calibrationbutton"
             style="?android:attr/buttonStyle"
             android:layout_width="0px"
@@ -87,7 +87,7 @@
             android:textSize="10sp"
             android:visibility="gone" />
 
-        <info.nightscout.androidaps.utils.SingleClickButton
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/overview_cgmbutton"
             style="?android:attr/buttonStyle"
             android:layout_width="0px"
@@ -100,7 +100,7 @@
             android:textSize="10sp"
             android:visibility="gone" />
 
-        <info.nightscout.androidaps.utils.SingleClickButton
+        <info.nightscout.androidaps.utils.ui.SingleClickButton
             android:id="@+id/overview_quickwizardbutton"
             style="?android:attr/buttonStyle"
             android:layout_width="0px"

--- a/app/src/main/res/layout/overview_fragment_nsclient_tablet.xml
+++ b/app/src/main/res/layout/overview_fragment_nsclient_tablet.xml
@@ -476,7 +476,7 @@
                 android:orientation="horizontal"
                 android:paddingRight="5dp">
 
-                <info.nightscout.androidaps.utils.SingleClickButton
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
                     android:id="@+id/overview_treatmentbutton"
                     style="?android:attr/buttonStyle"
                     android:layout_width="0px"
@@ -490,7 +490,7 @@
                     android:textColor="@color/colorTreatmentButton"
                     android:textSize="10sp" />
 
-                <info.nightscout.androidaps.utils.SingleClickButton
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
                     android:id="@+id/overview_insulinbutton"
                     style="?android:attr/buttonStyle"
                     android:layout_width="0px"
@@ -505,7 +505,7 @@
                     android:textSize="10sp"
                     android:visibility="gone" />
 
-                <info.nightscout.androidaps.utils.SingleClickButton
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
                     android:id="@+id/overview_carbsbutton"
                     style="?android:attr/buttonStyle"
                     android:layout_width="0px"
@@ -520,7 +520,7 @@
                     android:textSize="10sp"
                     android:visibility="gone" />
 
-                <info.nightscout.androidaps.utils.SingleClickButton
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
                     android:id="@+id/overview_wizardbutton"
                     style="?android:attr/buttonStyle"
                     android:layout_width="0px"
@@ -535,7 +535,7 @@
                     android:textSize="10sp"
                     android:visibility="gone" />
 
-                <info.nightscout.androidaps.utils.SingleClickButton
+                <info.nightscout.androidaps.utils.ui.SingleClickButton
                     android:id="@+id/overview_quickwizardbutton"
                     style="?android:attr/buttonStyle"
                     android:layout_width="0px"

--- a/core/src/main/java/info/nightscout/androidaps/utils/ui/SingleClickButton.java
+++ b/core/src/main/java/info/nightscout/androidaps/utils/ui/SingleClickButton.java
@@ -1,4 +1,4 @@
-package info.nightscout.androidaps.utils;
+package info.nightscout.androidaps.utils.ui;
 
 import android.app.Activity;
 import android.content.Context;
@@ -8,7 +8,6 @@ import android.util.AttributeSet;
 import android.view.View;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import info.nightscout.androidaps.logging.StacktraceLoggerWrapper;
 

--- a/omnipod/src/main/res/layout/omnipod_pod_mgmt.xml
+++ b/omnipod/src/main/res/layout/omnipod_pod_mgmt.xml
@@ -29,7 +29,7 @@
                 android:gravity="center"
                 android:textStyle="bold" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/initpod_init_pod"
                 style="?android:attr/buttonStyle"
                 android:layout_width="fill_parent"
@@ -50,7 +50,7 @@
                 android:layout_weight="0.5"
                 android:text="" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/initpod_remove_pod"
                 style="?android:attr/buttonStyle"
                 android:layout_width="fill_parent"
@@ -71,7 +71,7 @@
                 android:layout_weight="0.5"
                 android:text="" />
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/initpod_reset_pod"
                 style="?android:attr/buttonStyle"
                 android:layout_width="fill_parent"
@@ -93,7 +93,7 @@
                 android:text="" />
 
 
-            <info.nightscout.androidaps.utils.SingleClickButton
+            <info.nightscout.androidaps.utils.ui.SingleClickButton
                 android:id="@+id/initpod_pod_history"
                 style="?android:attr/buttonStyle"
                 android:layout_width="fill_parent"


### PR DESCRIPTION
SingleClickButton is a utility used in a number of modules and such should be
in core. While the app seems to built with the button in app, this wrong
structure should be fixed.

As the button is a UI element, the patch also moves the class to the package
info.nightscout.androidaps.utils.ui.