### PR TITLE
Daggerization fixes

### DIFF
--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/MedtronicCommunicationManager.java
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/MedtronicCommunicationManager.java
@@ -17,7 +17,6 @@ import info.nightscout.androidaps.plugins.pump.common.data.PumpStatus;
 import info.nightscout.androidaps.plugins.pump.common.defs.PumpDeviceState;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.RileyLinkCommunicationManager;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.RileyLinkConst;
-import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.RFSpy;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.RileyLinkCommunicationException;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.data.RFSpyResponse;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.data.RLMessage;

--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/MedtronicCommunicationManager.java
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/MedtronicCommunicationManager.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import dagger.android.HasAndroidInjector;
 import info.nightscout.androidaps.logging.LTag;
 import info.nightscout.androidaps.plugins.pump.common.data.PumpStatus;
 import info.nightscout.androidaps.plugins.pump.common.defs.PumpDeviceState;
@@ -73,9 +72,13 @@ public class MedtronicCommunicationManager extends RileyLinkCommunicationManager
 
     private boolean doWakeUpBeforeCommand = true;
 
+    // This empty constructor must be kept, otherwise dagger injection might break!
+    @Inject
+    public MedtronicCommunicationManager() {}
 
-    public MedtronicCommunicationManager(HasAndroidInjector injector) {
-        super(injector);
+    @Inject
+    public void onInit() {
+        // we can't do this in the constructor, as sp only gets injected after the constructor has returned
         medtronicPumpStatus.previousConnection = sp.getLong(
                 RileyLinkConst.Prefs.LastGoodDeviceCommunicationTime, 0L);
     }

--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/MedtronicCommunicationManager.java
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/comm/MedtronicCommunicationManager.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import info.nightscout.androidaps.logging.LTag;
 import info.nightscout.androidaps.plugins.pump.common.data.PumpStatus;
@@ -55,6 +56,7 @@ import info.nightscout.androidaps.plugins.pump.medtronic.util.MedtronicUtil;
  * This was mostly rewritten from Original version, and lots of commands and
  * functionality added.
  */
+@Singleton
 public class MedtronicCommunicationManager extends RileyLinkCommunicationManager {
 
     @Inject MedtronicPumpStatus medtronicPumpStatus;

--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/service/RileyLinkMedtronicService.java
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/service/RileyLinkMedtronicService.java
@@ -55,8 +55,9 @@ public class RileyLinkMedtronicService extends RileyLinkService {
     private boolean inPreInit = true;
 
 
+    // This empty constructor must be kept, otherwise dagger injection might break!
+    @Inject
     public RileyLinkMedtronicService() {
-        super();
     }
 
 

--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/service/RileyLinkMedtronicService.java
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/service/RileyLinkMedtronicService.java
@@ -41,9 +41,9 @@ public class RileyLinkMedtronicService extends RileyLinkService {
     @Inject MedtronicUIPostprocessor medtronicUIPostprocessor;
     @Inject MedtronicPumpStatus medtronicPumpStatus;
     @Inject RFSpy rfSpy;
+    @Inject MedtronicCommunicationManager medtronicCommunicationManager;
 
     private MedtronicUIComm medtronicUIComm;
-    private MedtronicCommunicationManager medtronicCommunicationManager;
     private IBinder mBinder = new LocalBinder();
 
     private boolean serialChanged = false;
@@ -102,8 +102,6 @@ public class RileyLinkMedtronicService extends RileyLinkService {
 
         rfspy.startReader();
 
-        // init rileyLinkCommunicationManager
-        medtronicCommunicationManager = new MedtronicCommunicationManager(injector);
         medtronicUIComm = new MedtronicUIComm(injector, aapsLogger, medtronicUtil, medtronicUIPostprocessor, medtronicCommunicationManager);
 
         aapsLogger.debug(LTag.PUMPCOMM, "RileyLinkMedtronicService newly constructed");

--- a/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/service/RileyLinkMedtronicService.java
+++ b/medtronic/src/main/java/info/nightscout/androidaps/plugins/pump/medtronic/service/RileyLinkMedtronicService.java
@@ -7,6 +7,7 @@ import android.os.Binder;
 import android.os.IBinder;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import info.nightscout.androidaps.logging.LTag;
 import info.nightscout.androidaps.plugins.pump.common.defs.PumpDeviceState;
@@ -34,6 +35,7 @@ import info.nightscout.androidaps.plugins.pump.medtronic.util.MedtronicUtil;
 /**
  * RileyLinkMedtronicService is intended to stay running when the gui-app is closed.
  */
+@Singleton
 public class RileyLinkMedtronicService extends RileyLinkService {
 
     @Inject MedtronicPumpPlugin medtronicPumpPlugin;

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/OmnipodCommunicationManager.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/OmnipodCommunicationManager.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import dagger.android.HasAndroidInjector;
 import info.nightscout.androidaps.logging.AAPSLogger;
 import info.nightscout.androidaps.logging.LTag;
 import info.nightscout.androidaps.plugins.pump.common.data.PumpStatus;
@@ -55,9 +54,9 @@ public class OmnipodCommunicationManager extends RileyLinkCommunicationManager {
 
     @Inject OmnipodPumpStatus omnipodPumpStatus;
 
+    // This empty constructor must be kept, otherwise dagger injection might break!
     @Inject
-    public OmnipodCommunicationManager(HasAndroidInjector injector) {
-        super(injector);
+    public OmnipodCommunicationManager() {
     }
 
     @Inject

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/OmnipodCommunicationManager.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/OmnipodCommunicationManager.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import info.nightscout.androidaps.logging.AAPSLogger;
 import info.nightscout.androidaps.logging.LTag;
@@ -49,7 +50,8 @@ import info.nightscout.androidaps.plugins.pump.omnipod.util.OmnipodConst;
 /**
  * Created by andy on 6/29/18.
  */
-// TODO make singleton and rename to OmnipodRileyLinkCommunicationManager
+// TODO rename to OmnipodRileyLinkCommunicationManager
+@Singleton
 public class OmnipodCommunicationManager extends RileyLinkCommunicationManager {
 
     @Inject OmnipodPumpStatus omnipodPumpStatus;

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/OmnipodCommunicationManager.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/OmnipodCommunicationManager.java
@@ -8,13 +8,11 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import info.nightscout.androidaps.logging.AAPSLogger;
 import info.nightscout.androidaps.logging.LTag;
 import info.nightscout.androidaps.plugins.pump.common.data.PumpStatus;
 import info.nightscout.androidaps.plugins.pump.common.defs.PumpDeviceState;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.RileyLinkCommunicationManager;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.RileyLinkConst;
-import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.RFSpy;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.RileyLinkCommunicationException;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.data.RLMessage;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.defs.RLMessageType;

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/RileyLinkCommunicationManager.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/RileyLinkCommunicationManager.java
@@ -36,11 +36,10 @@ public abstract class RileyLinkCommunicationManager {
     @Inject protected RileyLinkServiceData rileyLinkServiceData;
     @Inject protected ServiceTaskExecutor serviceTaskExecutor;
     @Inject protected RFSpy rfspy;
+    @Inject protected HasAndroidInjector injector;
 
     private final int SCAN_TIMEOUT = 1500;
     private final int ALLOWED_PUMP_UNREACHABLE = 10 * 60 * 1000; // 10 minutes
-
-    public final HasAndroidInjector injector;
 
     protected int receiverDeviceAwakeForMinutes = 1; // override this in constructor of specific implementation
     protected String receiverDeviceID; // String representation of receiver device (ex. Pump (xxxxxx) or Pod (yyyyyy))
@@ -48,12 +47,6 @@ public abstract class RileyLinkCommunicationManager {
     //    protected PumpStatus pumpStatus;
     private long nextWakeUpRequired = 0L;
     private int timeoutCount = 0;
-
-
-    public RileyLinkCommunicationManager(HasAndroidInjector injector) {
-        this.injector = injector;
-        this.injector.androidInjector().inject(this);
-    }
 
 
     // All pump communications go through this function.


### PR DESCRIPTION
- Turn `OmnipodCommunicationManager` into a singleton
- Turn `MedtronicCommunicationManager` into a singleton
- Turn `RileyLinkMedtronicService` into a singleton
- Use dagger to inject `HasAndroidInjector` into `RileyLinkCommunicationManager`
- Use dagger to inject `MedtronicCommunicationManager` into `RileyLinkMedtronicService`
- Avoid manual calls to `injector.inject()`, that seems to be considered bad style