### PR TITLE
Show total dose in fragment

### DIFF
--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodFragment.kt
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodFragment.kt
@@ -281,7 +281,13 @@ class OmnipodFragment : DaggerFragment() {
                 .getTempBasalFromHistory(System.currentTimeMillis())?.toStringFull() ?: "-"
 
             // total delivered
-            omnipod_total_delivered.text = resourceHelper.gs(R.string.omnipod_total_delivered,podStateManager.totalInsulinDelivered);
+            omnipod_total_delivered.text = podStateManager.totalInsulinDelivered.let {
+                when {
+                    it == null                        -> "-"
+                    it < OmnipodConst.POD_SETUP_UNITS -> resourceHelper.gs(R.string.omnipod_total_delivered_pod_preparing)
+                    else                              -> resourceHelper.gs(R.string.omnipod_total_delivered, it - OmnipodConst.POD_SETUP_UNITS);
+                }
+            }
 
             // reservoir
             if (podStateManager.reservoirLevel == null) {

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodFragment.kt
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodFragment.kt
@@ -281,12 +281,10 @@ class OmnipodFragment : DaggerFragment() {
                 .getTempBasalFromHistory(System.currentTimeMillis())?.toStringFull() ?: "-"
 
             // total delivered
-            omnipod_total_delivered.text = podStateManager.totalInsulinDelivered.let {
-                when {
-                    it == null                        -> "-"
-                    it < OmnipodConst.POD_SETUP_UNITS -> resourceHelper.gs(R.string.omnipod_total_delivered_pod_preparing)
-                    else                              -> resourceHelper.gs(R.string.omnipod_total_delivered, it - OmnipodConst.POD_SETUP_UNITS);
-                }
+            omnipod_total_delivered.text = if (podStateManager.isPodActivationCompleted) {
+                resourceHelper.gs(R.string.omnipod_total_delivered, podStateManager.totalInsulinDelivered - OmnipodConst.POD_SETUP_UNITS);
+            } else {
+                "-"
             }
 
             // reservoir

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodFragment.kt
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodFragment.kt
@@ -248,6 +248,7 @@ class OmnipodFragment : DaggerFragment() {
             omnipod_pod_firmware_version.text = "-"
             omnipod_pod_expiry.text = "-"
             omnipod_basabasalrate.text = "-"
+            omnipod_total_delivered.text = "-"
             omnipod_reservoir.text = "-"
             omnipod_tempbasal.text = "-"
             omnipod_lastbolus.text = "-"
@@ -278,6 +279,9 @@ class OmnipodFragment : DaggerFragment() {
 
             omnipod_tempbasal.text = activePlugin.activeTreatments
                 .getTempBasalFromHistory(System.currentTimeMillis())?.toStringFull() ?: "-"
+
+            // total delivered
+            omnipod_total_delivered.text = resourceHelper.gs(R.string.omnipod_total_delivered,podStateManager.totalInsulinDelivered);
 
             // reservoir
             if (podStateManager.reservoirLevel == null) {

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/message/response/StatusResponse.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/message/response/StatusResponse.java
@@ -20,6 +20,7 @@ public class StatusResponse extends MessageBlock {
     private final PodProgressStatus podProgressStatus;
     private final Duration timeActive;
     private final Double reservoirLevel;
+    private final int ticksDelivered;
     private final double insulinDelivered;
     private final double insulinNotDelivered;
     private final byte podMessageCounter;
@@ -40,7 +41,8 @@ public class StatusResponse extends MessageBlock {
         int highInsulinBits = (encodedData[2] & 0xF) << 9;
         int middleInsulinBits = ByteUtil.convertUnsignedByteToInt(encodedData[3]) << 1;
         int lowInsulinBits = ByteUtil.convertUnsignedByteToInt(encodedData[4]) >>> 7;
-        insulinDelivered = OmnipodConst.POD_PULSE_SIZE * (highInsulinBits | middleInsulinBits | lowInsulinBits);
+        ticksDelivered = (highInsulinBits | middleInsulinBits | lowInsulinBits);
+        insulinDelivered = OmnipodConst.POD_PULSE_SIZE * ticksDelivered;
         podMessageCounter = (byte) ((encodedData[4] >>> 3) & 0xf);
 
         insulinNotDelivered = OmnipodConst.POD_PULSE_SIZE * (((encodedData[4] & 0x03) << 8) | ByteUtil.convertUnsignedByteToInt(encodedData[5]));
@@ -74,6 +76,8 @@ public class StatusResponse extends MessageBlock {
     public Double getReservoirLevel() {
         return reservoirLevel;
     }
+
+    public int getTicksDelivered() { return ticksDelivered; }
 
     public double getInsulinDelivered() {
         return insulinDelivered;

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/defs/state/PodStateManager.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/defs/state/PodStateManager.java
@@ -302,6 +302,8 @@ public abstract class PodStateManager {
         return getSafe(() -> podState.getReservoirLevel());
     }
 
+    public final Double getTotalInsulinDelivered() { return getSafe(() -> podState.getTotalInsulinDelivered()); }
+
     public final Duration getScheduleOffset() {
         DateTime now = getTime();
         return new Duration(now.withTimeAtStartOfDay(), now);
@@ -373,6 +375,7 @@ public abstract class PodStateManager {
             podState.setActiveAlerts(statusResponse.getAlerts());
             podState.setLastDeliveryStatus(statusResponse.getDeliveryStatus());
             podState.setReservoirLevel(statusResponse.getReservoirLevel());
+            podState.setTotalTicksDelivered(statusResponse.getTicksDelivered());
             podState.setPodProgressStatus(statusResponse.getPodProgressStatus());
             podState.setLastUpdatedFromStatusResponse(DateTime.now());
         });
@@ -469,6 +472,7 @@ public abstract class PodStateManager {
         private DateTime expiresAt;
         private PodInfoFaultEvent faultEvent;
         private Double reservoirLevel;
+        private Integer totalTicksDelivered;
         private boolean suspended;
         private NonceState nonceState;
         private PodProgressStatus podProgressStatus;
@@ -601,6 +605,20 @@ public abstract class PodStateManager {
         void setReservoirLevel(Double reservoirLevel) {
             this.reservoirLevel = reservoirLevel;
         }
+
+        public Integer getTotalTicksDelivered() {
+            return totalTicksDelivered;
+        }
+
+        public Double getTotalInsulinDelivered() {
+            if (totalTicksDelivered != null) {
+                return totalTicksDelivered * OmnipodConst.POD_PULSE_SIZE;
+            } else {
+                return null;
+            }
+        }
+
+        void setTotalTicksDelivered(Integer totalTicksDelivered) { this.totalTicksDelivered = totalTicksDelivered; }
 
         public boolean isSuspended() {
             return suspended;

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/util/OmnipodConst.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/util/OmnipodConst.java
@@ -53,4 +53,5 @@ public class OmnipodConst {
 
     public static final double POD_PRIME_BOLUS_UNITS = 2.6;
     public static final double POD_CANNULA_INSERTION_BOLUS_UNITS = 0.5;
+    public static final double POD_SETUP_UNITS = POD_PRIME_BOLUS_UNITS + POD_CANNULA_INSERTION_BOLUS_UNITS;
 }

--- a/omnipod/src/main/res/layout/omnipod_fragment.xml
+++ b/omnipod/src/main/res/layout/omnipod_fragment.xml
@@ -517,6 +517,42 @@
                     android:layout_marginBottom="5dp"
                     android:background="@color/listdelimiter" />
 
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1.5"
+                        android:gravity="end"
+                        android:paddingRight="5dp"
+                        android:text="@string/omnipod_total_delivered_label"
+                        android:textSize="14sp" />
+
+                    <TextView
+                        android:layout_width="5dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="0"
+                        android:gravity="center_horizontal"
+                        android:paddingStart="2dp"
+                        android:paddingEnd="2dp"
+                        android:text=":"
+                        android:textSize="14sp" />
+
+                    <TextView
+                        android:id="@+id/omnipod_total_delivered"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="start"
+                        android:paddingLeft="5dp"
+                        android:textColor="@android:color/white"
+                        android:textSize="14sp" />
+
+                </LinearLayout>
+
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/omnipod/src/main/res/values/strings.xml
+++ b/omnipod/src/main/res/values/strings.xml
@@ -27,7 +27,6 @@
     <string name="omnipod_pod_mgmt">Pod Mgmt</string>
     <string name="omnipod_pod_status">Pod Status</string>
     <string name="omnipod_total_delivered_label">Total Delivered</string>
-    <string name="omnipod_total_delivered_pod_preparing">Pod Preparing</string>
     <string name="omnipod_total_delivered">%1$.2f U</string>
     <string name="omnipod_reservoir_left">%1$.2f U left</string>
     <string name="omnipod_reservoir_over50">Over 50 U</string>

--- a/omnipod/src/main/res/values/strings.xml
+++ b/omnipod/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="omnipod_pod_mgmt">Pod Mgmt</string>
     <string name="omnipod_pod_status">Pod Status</string>
     <string name="omnipod_total_delivered_label">Total Delivered</string>
+    <string name="omnipod_total_delivered_pod_preparing">Pod Preparing</string>
     <string name="omnipod_total_delivered">%1$.2f U</string>
     <string name="omnipod_reservoir_left">%1$.2f U left</string>
     <string name="omnipod_reservoir_over50">Over 50 U</string>

--- a/omnipod/src/main/res/values/strings.xml
+++ b/omnipod/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="omnipod_moments_ago">Moments ago</string>
     <string name="omnipod_pod_mgmt">Pod Mgmt</string>
     <string name="omnipod_pod_status">Pod Status</string>
+    <string name="omnipod_total_delivered_label">Total Delivered</string>
+    <string name="omnipod_total_delivered">%1$.2f U</string>
     <string name="omnipod_reservoir_left">%1$.2f U left</string>
     <string name="omnipod_reservoir_over50">Over 50 U</string>
     <string name="omnipod_pod_address">Pod Address</string>

--- a/omnipod/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/message/response/StatusResponseTest.java
+++ b/omnipod/src/test/java/info/nightscout/androidaps/plugins/pump/omnipod/comm/message/response/StatusResponseTest.java
@@ -45,6 +45,7 @@ public class StatusResponseTest {
         assertEquals(PodProgressStatus.ABOVE_FIFTY_UNITS, statusResponse.getPodProgressStatus());
         assertNull("Reservoir level should be null", statusResponse.getReservoirLevel());
         assertEquals(Duration.standardMinutes(1307).getMillis(), statusResponse.getTimeActive().getMillis());
+        assertEquals(1201, statusResponse.getTicksDelivered());
         assertEquals(60.05, statusResponse.getInsulinDelivered(), 0.000001);
         assertEquals(15, statusResponse.getPodMessageCounter());
         assertEquals(0, statusResponse.getInsulinNotDelivered(), 0.000001);
@@ -62,6 +63,7 @@ public class StatusResponseTest {
         assertEquals(PodProgressStatus.FIFTY_OR_LESS_UNITS, statusResponse.getPodProgressStatus());
         assertEquals(24.4, statusResponse.getReservoirLevel(), 0.000001);
         assertEquals(Duration.standardMinutes(4261).getMillis(), statusResponse.getTimeActive().getMillis());
+        assertEquals(3134, statusResponse.getTicksDelivered());
         assertEquals(156.7, statusResponse.getInsulinDelivered(), 0.000001);
         assertEquals(13, statusResponse.getPodMessageCounter());
         assertEquals(0, statusResponse.getInsulinNotDelivered(), 0.000001);
@@ -79,6 +81,7 @@ public class StatusResponseTest {
         assertEquals(Duration.standardMinutes(8191).getMillis(), statusResponse.getTimeActive().getMillis());
         assertEquals(OmnipodConst.POD_PULSE_SIZE * 1023, statusResponse.getInsulinNotDelivered(), 0.000001);
         assertNull("Reservoir level should be null", statusResponse.getReservoirLevel());
+        assertEquals(8191, statusResponse.getTicksDelivered());
         assertEquals(OmnipodConst.POD_PULSE_SIZE * 8191, statusResponse.getInsulinDelivered(), 0.0000001);
         assertEquals(15, statusResponse.getPodMessageCounter());
         assertEquals(8, statusResponse.getAlerts().getAlertSlots().size());
@@ -94,6 +97,7 @@ public class StatusResponseTest {
         assertTrue(Duration.standardMinutes(3547).isEqual(statusResponse.getTimeActive()));
         assertEquals(DeliveryStatus.NORMAL, statusResponse.getDeliveryStatus());
         assertEquals(PodProgressStatus.FIFTY_OR_LESS_UNITS, statusResponse.getPodProgressStatus());
+        assertEquals(2589, statusResponse.getTicksDelivered());
         assertEquals(129.45, statusResponse.getInsulinDelivered(), 0.00001);
         assertEquals(46.00, statusResponse.getReservoirLevel(), 0.00001);
         assertEquals(2.2, statusResponse.getInsulinNotDelivered(), 0.0001);


### PR DESCRIPTION
This adds the total insulin delivered by the current pod to the omnipod fragment. It also includes the insulin delivery ticks for priming and cannula insertion, but I consider it a nice estimate of remaining insulin before we reach the 50 units level.

The code works on my setup.